### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=recipe-combinator-main] Move to circuit-combinator subgroup if SchallCircuitGroup is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,3 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["recipe-combinator-main"].subgroup = "circuit-combinator"
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
-    "recipe_combinator >= 0.1.2"
+    "recipe_combinator >= 0.1.2",
+    "? SchallCircuitGroups >= 2.0.0"
   ]
 }

--- a/info.json
+++ b/info.json
@@ -9,6 +9,6 @@
   "dependencies": [
     "base >= 2.0.0",
     "recipe_combinator >= 0.1.2",
-    "? SchallCircuitGroups >= 2.0.0"
+    "? SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=recipe-combinator-main] Move to circuit-combinator subgroup if SchallCircuitGroup is installed.